### PR TITLE
Edit speaker names

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,12 +26,12 @@ Start time (CEST) | End time (CEST) | Presenter               | Title           
 :----------|:---------|:------------------------|:-------------------------------|:---------
 13:00 | 13:10 | Organizing committee | Introduction | TBA
 13:10 | 13:40 | Andreas Bergthaler (CeMM Vienna) | _Hidden tales about intra-host diversity, transmission bottlenecks and super-spreading events in the SARS-CoV-2 genome_ | TBA
-13:40 | 14:10 | Tal Dahan (GMI & Weizman Institute) | _Resilience of a wild wheat population structure over 36 years of collection_ | TBA
+13:40 | 14:10 | Tal Dahan/Tom Ellis (GMI & Weizman Institute) | _Resilience of a wild wheat population structure over 36 years of collection_ | TBA
 14:10 | 14:40 | Nayuta Yamashita (University of Veterinary Medicine Vienna)| _Feeding ecology of dry forest lemurs_ | TBA
 14:45 | 15:25 | Break and [poster session](#poster-session) |    |    
 15:30 | 16:00 | Alevtina Koreshova (IMBA Vienna) | _Selfish toxin-antidote elements in animals: discovery, mechanisms and implications for speciation_ | TBA
 16:00 | 16:30 | Sheng-Kai Hsu (University of Veterinary Medicine Vienna) | _Evolution of reproductive isolation during adaptation in allopatric populations with shared ancestry_ | TBA
-16:30 | 17:00 | Reka Kelemen (IST Austria) | _Evolutionary and functional genomics of the t-haplotype, a model meiotic driver_ | TBA
+16:30 | 17:00 | Réka Kelemen (IST Austria) | _Evolutionary and functional genomics of the t-haplotype, a model meiotic driver_ | TBA
 
 ## Sign-up
 


### PR DESCRIPTION
Two changes to speaker names in the schedule:
- Replaced a e with an é in Réka Kelemen's name.
- Changed "Tal Dahan" to "Tal Dahan/Tom Ellis".